### PR TITLE
ci.yml: Add another platform for tests, `ubuntu-latest --no-daemon`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        install_options: [""]
+        include:
+          - os: ubuntu-latest
+            install_options: "--no-daemon"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -22,6 +26,7 @@ jobs:
         fetch-depth: 0
     - uses: cachix/install-nix-action@V27
       with:
+        install_options: ${{ matrix.install_options }}
         # The sandbox would otherwise be disabled by default on Darwin
         extra_nix_config: "sandbox = true"
     - run: echo CACHIX_NAME="$(echo $GITHUB_REPOSITORY-install-tests | tr "[A-Z]/" "[a-z]-")" >> $GITHUB_ENV


### PR DESCRIPTION
Add another platform for the `tests` stage, `ubuntu-latest, --no-daemon`.

This currently fails.